### PR TITLE
Yarn start now only runs the start react scripts, when in development…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "start-js": "react-scripts start",
-    "start": "npm-run-all -p watch-css start-js",
+    "start-dev": "npm-run-all -p watch-css start-js",
+    "start" : "react-scripts start",
     "build": "npm run build-css && react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"


### PR DESCRIPTION
… use start-dev to run the css watcher and sass compiler